### PR TITLE
Add pyppeteer screenshot engine fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Hawkeye
-Fuzzing
+
+## Screenshot support
+
+Hawkeye can capture page screenshots without relying on external Go-based tools. Pass
+`--screenshot-engine pyppeteer` to use the bundled headless Chromium controller from
+[`pyppeteer`](https://github.com/pyppeteer/pyppeteer). Install the dependency with
+`pip install pyppeteer` when you need screenshot support.


### PR DESCRIPTION
## Summary
- add a pyppeteer-based screenshot engine as an alternative to the gowitness CLI
- harden dependency checks and document the new screenshot option in the README

## Testing
- python3 -m compileall hawkeye.py

------
https://chatgpt.com/codex/tasks/task_e_68daeb56d5088322a6c7166624da9bb7